### PR TITLE
Add directory param support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Otherwise, you need to run it with node:
 
     $ node nodelint path/to/your/file.js
 
+You can also specify a directory param and nodelint will find all .js files under that directory and its subdirectories:
+
+    $ node nodelint dir1/ dir2/
+
 Enjoy!
 
 
@@ -48,7 +52,7 @@ You can set JSLint options by modifying the default `config.js` file or even
 override the default config by passing another config file with the optional
 `--config` parameter, e.g.
 
-    $ nodelint file1 file2 --config path/to/your/config/file.js
+    $ nodelint file1 file2 dir1 dir2 --config path/to/your/config/file.js
 
 For example, if the default config.js has:
 
@@ -150,7 +154,7 @@ credits
 
 - [Matt Ranney][mranney], updated nodelint to use sys.error.
 
-- [Cliffano Subagio], added npm installation support and XML reporter.
+- [Cliffano Subagio], added npm installation support, XML reporter, and directory param support.
 
 [tav]: http://tav.espians.com
 [felixge]: http://debuggable.com

--- a/nodelint
+++ b/nodelint
@@ -141,6 +141,25 @@
     reporter(results, error_prefix, error_suffix);
     return retval; 
   }
+
+  // based on mikeal/node-utils' walkSync
+  function walkDir(base, callback) {
+    var filenames = fs.readdirSync(base),
+      coll = filenames.reduce(function (acc, name) {
+      var abspath = path.join(base, name);
+      if (fs.statSync(abspath).isDirectory()) {
+        acc.dirs.push(name);
+      } else {
+        acc.names.push(name);
+      }
+      return acc;
+    }, {"names": [], "dirs": []});
+    callback(base, coll.dirs, coll.names);
+    coll.dirs.forEach(function (d) {
+      var abspath = path.join(base, d);
+      walkDir(abspath, callback);
+    });
+  }
   
 // -----------------------------------------------------------------------------
 // run the file as a script if called directly, i.e. not imported via require()
@@ -165,7 +184,18 @@
       reporter_param_found = false;
     } else if ((param === '--help') || (param === '-h')) {
     } else {
-      files.push(param);
+      var stat = fs.statSync(param);
+      if (stat.isDirectory()) {
+        walkDir(param, function (base, dirs, names) {
+          for (var i = 0, ln = names.length; i < ln; i += 1) {
+            if (names[i].match(/.js$/)) {
+              files.push(path.join(base, names[i]));
+            }
+          }
+        });
+      } else {
+        files.push(param);
+      }
     }
   });
   


### PR DESCRIPTION
I've added directory param support to nodelint.
This solves the scenario where there are many javascript files to lint within many subdirectories. So the user doesn't have to specify many paths to file names, and instead specify the root paths.
e.g.
nodelint lib/ lib-extra/ 
