### PR TITLE
Add --xml-reporter and clean up walkDir

### DIFF
--- a/nodelint
+++ b/nodelint
@@ -13,7 +13,8 @@
 /*jslint evil: true */
 
 (function () {
-  var fs = require('fs'),
+  var f = require('file'),
+      fs = require('fs'),
       path = require('path'),
       util = require('util'),
       SCRIPT_DIRECTORY,
@@ -145,25 +146,6 @@
     return retval;
   }
 
-  // based on mikeal/node-utils' walkSync
-  function walkDir(base, callback) {
-    var filenames = fs.readdirSync(base),
-      coll = filenames.reduce(function (acc, name) {
-      var abspath = path.join(base, name);
-      if (fs.statSync(abspath).isDirectory()) {
-        acc.dirs.push(name);
-      } else {
-        acc.names.push(name);
-      }
-      return acc;
-    }, {"names": [], "dirs": []});
-    callback(base, coll.dirs, coll.names);
-    coll.dirs.forEach(function (d) {
-      var abspath = path.join(base, d);
-      walkDir(abspath, callback);
-    });
-  }
-
 // -----------------------------------------------------------------------------
 // run the file as a script if called directly, i.e. not imported via require()
 // -----------------------------------------------------------------------------
@@ -173,7 +155,7 @@
 
   // a very basic pseudo --options parser
   params.forEach(function (param) {
-    var content, pkg, stat, i;
+    var content, pkg, stat;
     if (param.slice(0, 9) === "--config=") {
       config_file = param.slice(9);
     } else if (param === '--config') {
@@ -198,12 +180,12 @@
     } else {
       stat = fs.statSync(param);
       if (stat.isDirectory()) {
-        walkDir(param, function (base, dirs, names) {
-          for (i = 0, ln = names.length; i < ln; i += 1) {
-            if (names[i].match(/\.js$/)) {
-              files.push(path.join(base, names[i]));
+        f.walkSync(param, function (base, dirs, names) {
+          names.forEach(function (name) {
+            if (name.match(/.js$/)) {
+              files.push(path.join(base, name));
             }
-          }
+          });
         });
       } else {
         files.push(param);

--- a/nodelint
+++ b/nodelint
@@ -163,6 +163,8 @@
     } else if (config_param_found) {
       config_file = param;
       config_param_found = false;
+    } else if (param === '--xml-reporter') {
+      reporter_file = path.join(__dirname, 'examples/reporters/xml.js');
     } else if (param === '--reporter') {
       reporter_param_found = true;
     } else if (reporter_param_found) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "git://github.com/tav/nodelint.git"
   },
+  "dependencies": {
+    "file": ">=0.1.1"
+  },
   "bugs": { "web": "https://github.com/tav/nodelint/issues" },
   "licenses": {
     "type": "Public Domain"


### PR DESCRIPTION
We have a number of projects which need to generate lint report in xml, and each one ends up having a nodelint reporter xml. This gets repetitive, so I think it would be great if nodelint itself supports this via --xml-reporter flag.

I also replaced walkDir snippet with file.walkSync, that's slightly cleaner.
