### PR TITLE
process.ARGV was removed in favor of process.argv

### DIFF
--- a/nodelint
+++ b/nodelint
@@ -150,7 +150,7 @@
 // run the file as a script if called directly, i.e. not imported via require()
 // -----------------------------------------------------------------------------
 
-  params = process.ARGV.splice(2);
+  params = process.argv.splice(2);
   files = [];
 
   // a very basic pseudo --options parser


### PR DESCRIPTION
Backwards compatibility in node has been removed as of v0.5.10. Running with `process.ARGV` kills the process.
