### PR TITLE
NPM throws a warning when using "web" key for "bugs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "file": ">=0.1.1"
   },
-  "bugs": { "web": "https://github.com/tav/nodelint/issues" },
+  "bugs": { "url": "https://github.com/tav/nodelint/issues" },
   "licenses": {
     "type": "Public Domain"
   },


### PR DESCRIPTION
This removes the warning, but preserves functionality.
