### PR TITLE
allow && in nodelint's xml report

### DIFF
--- a/examples/reporters/xml.js
+++ b/examples/reporters/xml.js
@@ -11,7 +11,7 @@ var path = require('path'),
 function reporter(results) {
 
   function escape(str) {
-    return (str) ? str.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;') : '';
+    return (str) ? str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;') : '';
   }
 
   var i, error, len, file,


### PR DESCRIPTION
if you have a report on a line like: if(a && b) this fails to generate a valid xml because && will be written as is in the xml, while it should be &amp;&amp; this small fix fixes that.
