### PR TITLE
Vim Reporter Changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ all: build doc
 
 build: stamp-build
 
-stamp-build: dependencies jslint/jslint.js nodelint config.js
+stamp-build: stamp-dependencies jslint/jslint.js nodelint config.js
 	touch stamp-build;
 	cp $^ $(BUILDDIR);
+	mv $(BUILDDIR)/stamp-dependencies $(BUILDDIR)/dependencies	
 	perl -pi -e 's{^\s*SCRIPT_DIRECTORY =.*?\n}{}ms' $(BUILDDIR)/nodelint
 	perl -pi -e 's{path\.join\(SCRIPT_DIRECTORY, '\''config.js'\''\)}{"$(ETCDIR)/nodelint.conf"}' $(BUILDDIR)/nodelint
 	perl -pi -e 's{path\.join\(SCRIPT_DIRECTORY, '\''jslint/jslint\.js'\''\)}{"$(PACKAGEDATADIR)/jslint.js"}' $(BUILDDIR)/nodelint

--- a/lib/reporters/vim.js
+++ b/lib/reporters/vim.js
@@ -39,9 +39,11 @@ exports.report = function report(results) {
       file = results[i].file;
       error = results[i].error;
 
-      str += file  + 'line ' + error.line +
-        ' column ' + error.character +
-        ' Error: ' + error.reason + ' ' +
+      /* use errorformat %f:%l:%c:%m from the default errorformat 
+       * (:set errorformat?). See also :help errorformat
+       */
+      str += file  + ':' + error.line + ':' + error.character +
+        ':' + error.reason + ' ' +
         (error.evidence || '').replace(error_regexp, "$1");
 
       str += (i === len - 1) ? '' : '\n';


### PR DESCRIPTION
The vim reporter didn't work properly, because of a missing delimiter between filename
an line number. I also changed the used errorformat to %f:%l:%c:%m. Which means
filename:line:colum:error message.

Regards 
Dafo
