### PR TITLE
Bump jslint to support node 6

### DIFF
--- a/nodelint
+++ b/nodelint
@@ -8,7 +8,7 @@
  * See the README.md for full credits of the awesome contributors!
  */
 
-/*global JSLINT, options */
+/*global jslint, options */
 /*jslint evil: true */
 
 (function () {
@@ -30,7 +30,7 @@
     usage =
     "Usage: nodelint file.js [file2 file3 ...] [options]\n" +
     "Options:\n\n" +
-    "  --config FILE     the path to a config.js file with JSLINT options\n" +
+    "  --config FILE     the path to a config.js file with jslint options\n" +
     "  --reporter FILE   optional path to a reporter.js file to customize the output\n" +
     "  --list-reporters  list available build-in reporters\n" +
     "  -h, --help        display this help and exit\n" +
@@ -105,9 +105,9 @@
       // remove any shebangs
       source = source.replace(/^\#\!.*/, '');
 
-      if (!JSLINT(source, current_file_options)) {
-        for (i = 0; i < JSLINT.errors.length; i += 1) {
-          error = JSLINT.errors[i];
+      if (!jslint(source, current_file_options)) {
+        for (i = 0; i < jslint.errors.length; i += 1) {
+          error = jslint.errors[i];
           if (error) {
             results.push({file: file, error: error});
           }


### PR DESCRIPTION
Current fork does not support node 6 (new object features break compatibility).  Work has been done in upstream jslint to support node 6.x so we want to update the submodule with latest version.
